### PR TITLE
Added support for compilation under OSX

### DIFF
--- a/Makefile.rtlosx
+++ b/Makefile.rtlosx
@@ -1,0 +1,23 @@
+CFLAGS= -Ofast -Wall -pthread -D WITH_RTL -D OSX -I /usr/local/include/librtlsdr
+LDLIBS= -lm -pthread  -lusb-1.0  -L/usr/local/lib -lrtlsdr # -lrt
+
+CC=gcc
+
+all:	vdlm2dec
+
+vdlm2dec:	main.o rtl.o d8psk.o vdlm2.o viterbi.o rs.o crc.o out.o outacars.o label.o outxid.o cJSON.o
+	$(CC)  main.o rtl.o d8psk.o vdlm2.o viterbi.o rs.o crc.o out.o outacars.o label.o outxid.o cJSON.o -o $@ $(LDLIBS)
+
+outacars.o:	outacars.c acars.h crc.h vdlm2.h cJSON.h
+outxid.o:	outxid.c acars.h vdlm2.h cJSON.h
+out.o:		out.c acars.h vdlm2.h
+main.o: main.c vdlm2.h
+d8psk.o: d8psk.c d8psk.h vdlm2.h
+vdlm2.o: vdlm2.c vdlm2.h acars.h crc.h
+viterbi.o: viterbi.c vdlm2.h
+rtl.o: rtl.c vdlm2.h
+cJSON.o: cJSON.c cJSON.h
+label.o: label.c 
+
+clean:
+	@rm -f *.o vdlm2dec

--- a/rtl.c
+++ b/rtl.c
@@ -36,6 +36,60 @@ unsigned int Fc;
 static rtlsdr_dev_t *dev = NULL;
 static int status = 0;
 
+#ifdef OSX
+#ifndef PTHREAD_BARRIER_SERIAL_THREAD 
+#define PTHREAD_BARRIER_SERIAL_THREAD   1
+
+typedef struct pthread_barrier {
+  pthread_mutex_t         mutex;
+  pthread_cond_t          cond;
+  volatile uint32_t       flag;
+  size_t                  count;
+  size_t                  num;
+} pthread_barrier_t;
+#endif 
+
+int pthread_barrier_init(pthread_barrier_t *bar, int attr, int num)
+{
+  int ret = 0;
+  if ((ret = pthread_mutex_init(&(bar->mutex), 0))) return ret;
+  if ((ret = pthread_cond_init(&(bar->cond), 0))) return ret;
+  bar->flag = 0;
+  bar->count = 0;
+  bar->num = num;
+  return 0;
+}
+
+int pthread_barrier_wait(pthread_barrier_t *bar)
+{
+  int ret = 0;
+  uint32_t flag = 0;
+
+  if ((ret = pthread_mutex_lock(&(bar->mutex)))) return ret;
+
+  flag = bar->flag;
+  bar->count++;
+
+  if (bar->count == bar->num) {
+    bar->count = 0;
+    bar->flag = 1 - bar->flag;
+    if ((ret = pthread_cond_broadcast(&(bar->cond)))) return ret;
+    if ((ret = pthread_mutex_unlock(&(bar->mutex)))) return ret;
+    return PTHREAD_BARRIER_SERIAL_THREAD;
+  }
+
+  while (1) {
+    if (bar->flag == flag) {
+      ret = pthread_cond_wait(&(bar->cond), &(bar->mutex));
+      if (ret) return ret;
+      } else { break; }
+    }
+
+  if ((ret = pthread_mutex_unlock(&(bar->mutex)))) return ret;
+  return 0;
+}
+#endif
+
 /* function verbose_device_search by Kyle Keen
  * from http://cgit.osmocom.org/rtl-sdr/tree/src/convenience/convenience.c
  */

--- a/vdlm2.h
+++ b/vdlm2.h
@@ -84,6 +84,21 @@ typedef struct {
 
 #define JSONBUFLEN 30000
 
+#ifdef OSX
+#define PTHREAD_BARRIER_SERIAL_THREAD   1
+
+typedef struct pthread_barrier {
+  pthread_mutex_t         mutex;
+  pthread_cond_t          cond;
+  volatile uint32_t       flag;
+  size_t                  count;
+  size_t                  num;
+} pthread_barrier_t;
+
+int pthread_barrier_init(pthread_barrier_t *bar, int attr, int num);
+int pthread_barrier_wait(pthread_barrier_t *bar);
+#endif
+
 extern unsigned int Fc;
 extern pthread_barrier_t Bar1, Bar2;
 


### PR DESCRIPTION
The pthread support under OSX doesn't support pthread barrier, namely it creates a compilation error due to missing structure struct pthread_barrier.
I copied a solution from the web and added to the source.
