### PR TITLE
Expand ID string to 32 chars (vdlm2dec)

### DIFF
--- a/main.c
+++ b/main.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
         char *lblf=NULL;
 
         gethostname(sys_hostname, sizeof(sys_hostname));
-        idstation = strndup(sys_hostname, 32);
+        idstation = strndup(sys_hostname, MAX_ID_LEN);
 
 	nbch = 0;
 	logfd = stdout;
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
                         break;
 		case 'i':
 			free(idstation);
-			idstation = strndup(optarg, 32);
+			idstation = strndup(optarg, MAX_ID_LEN);
 			break;
 		case 'b':
                         lblf=optarg;

--- a/main.c
+++ b/main.c
@@ -109,8 +109,7 @@ int main(int argc, char **argv)
         char *lblf=NULL;
 
         gethostname(sys_hostname, sizeof(sys_hostname));
-	sys_hostname[sizeof(sys_hostname) - 1] = '\0';
-        idstation = strdup(sys_hostname);
+        idstation = strndup(sys_hostname, 32);
 
 	nbch = 0;
 	logfd = stdout;
@@ -166,7 +165,7 @@ int main(int argc, char **argv)
                         break;
 		case 'i':
 			free(idstation);
-			idstation = strdup(optarg);
+			idstation = strndup(optarg, 32);
 			break;
 		case 'b':
                         lblf=optarg;

--- a/main.c
+++ b/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>
+#include <limits.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <string.h>

--- a/out.c
+++ b/out.c
@@ -159,8 +159,8 @@ static void buildjsonobj(unsigned int faddr,unsigned int taddr,int fromair,int i
         	cJSON_AddNumberToObject(json_obj, "fromaddr", faddr & 0xffffff);
         	cJSON_AddNumberToObject(json_obj, "icao", taddr & 0xffffff);
 	}
-        cJSON_AddNumberToObject(json_obj, "isresponse", isresponse);
-        cJSON_AddNumberToObject(json_obj, "isonground", isonground);
+        cJSON_AddNumberToObject(json_obj, "is_response", isresponse);
+        cJSON_AddNumberToObject(json_obj, "is_onground", isonground);
 }
 
 

--- a/out.c
+++ b/out.c
@@ -136,7 +136,7 @@ static void outjson()
 
 }
 
-static void buildjsonobj(unsigned int faddr,unsigned int taddr,int fromair,msgblk_t * blk)
+static void buildjsonobj(unsigned int faddr,unsigned int taddr,int fromair,int isresponse,int isonground,msgblk_t * blk)
 {
         char convert_tmp[8];
         double t = (double)blk->tv.tv_sec + ((double)blk->tv.tv_usec)/1e6;
@@ -159,6 +159,8 @@ static void buildjsonobj(unsigned int faddr,unsigned int taddr,int fromair,msgbl
         	cJSON_AddNumberToObject(json_obj, "fromaddr", faddr & 0xffffff);
         	cJSON_AddNumberToObject(json_obj, "icao", taddr & 0xffffff);
 	}
+        cJSON_AddNumberToObject(json_obj, "isresponse", isresponse);
+        cJSON_AddNumberToObject(json_obj, "isonground", isonground);
 }
 
 
@@ -460,7 +462,7 @@ void out(msgblk_t * blk, unsigned char *hdata, int l)
 	}
 
 	if((jsonout || sockfd >0) && !routeout) 
-		buildjsonobj(faddr,taddr,fromair,blk);
+		buildjsonobj(faddr,taddr,fromair,rep,gnd,blk);
 
 	dec=0;
 

--- a/vdlm2.h
+++ b/vdlm2.h
@@ -22,6 +22,8 @@
 
 #define MAXNBCHANNELS 8
 
+#define MAX_ID_LEN 48
+
 #ifdef WITH_RTL
 #define SDRINRATE 2000000
 #define SDRCLK  500


### PR DESCRIPTION
Hi,
(Same message for both acarsdec and vdlm2dec(THIS))

In both vdl2mdec and acarsdec, there is a "station ID".  acarsdec has it limited to 8 characters, and vdlm2dec doesn't have a limit.  I'm proposing bringing these in line together, at 32 characters.  (Also, this fixes a bug in acarsdec that is missing a free() before re-assigning idstation via cmdline arg.)

NOTE: acarsserv would also need to be modified to allow up to 32 chars for the station ID.

-Taner