### PR TITLE
Add option to use specific airspy device by serial number

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ It could decode up to 8 frequencies simultaneously ( but in the same 2Mhz range 
 It decodes ARINC-622 ATS applications (ADS-C, CPDLC) via [libacars](https://github.com/szpajder/libacars) library
 
 ## Usage
+
+For RTL-SDR:
+
 > vdlm2dec  [-l logfile]  [-g gain] [-i stid] [-v] [-q] [-J] [-l logfile] [-r rtldevicenumber]  Frequencies(Mhz)
 
- -r rtldevicenumber :	decode from rtl dongle number rtldevicenumber (don't set it for airspy)
- 
- -g gain :		set preamp gain in tenth of db (ie -g 90 for +9db) (rtl-sdr)
+For Airspy R2 / Mini:
 
- -g gain :		set linearity gain (0 to 21).By default use maximum gain (airspy)
+> vdlm2dec  [-l logfile]  [-g gain] [-i stid] [-v] [-q] [-J] [-l logfile] [-k airspy_serial ] Frequencies(Mhz)
 
  -p ppm :		set rtl sdr ppm frequency (rtl-sdr only)
 
@@ -39,6 +40,18 @@ It decodes ARINC-622 ATS applications (ADS-C, CPDLC) via [libacars](https://gith
  -E :			output empty messages
 
  -U :			output undecoded messages
+
+for the RTLSDR device
+
+ -r rtldevicenumber :	decode from rtl dongle number rtldevicenumber
+ 
+ -g gain :		set preamp gain in tenth of db (ie -g 90 for +9db) (rtl-sdr)
+
+for the AirSpy device
+
+ -g gain :		set linearity gain (0 to 21).By default use maximum gain (airspy)
+
+ -k airspy_serial_number :            decode from airspy device with supplied serial number specified in hex, ie 0xA74068C82F591693
 
  
 ## Examples
@@ -115,28 +128,6 @@ It depends on some external libraries :
     cmake .. -Dairspy=ON
     make
     sudo make install
-
-#### For airspy mini
-In vdlm2.h change :
-
-    #ifdef WITH_AIR
-    #define SDRINRATE 5000000
-    #define SDRCLK  1250
-    #endif
-
-into 
-
-    #ifdef WITH_AIR
-    #define SDRINRATE 6000000
-    #define SDRCLK  1500
-    #endif
-
-comment the following lines in air.c :
-
-    //airspy_r820t_write(device, 10, 0xB0 | (15-j));
-    //airspy_r820t_write(device, 11, 0xE0 | (15-i));
-
-then compile as for the airspy (see above)
 
 #### For raspberry Pi and others ARM machines :
 

--- a/air.c
+++ b/air.c
@@ -126,7 +126,7 @@ int initAirspy(char **argv, int optind, thread_param_t * param)
 		return -1;
 	}
 
-	airspy_get_samplerates(device, &count, NULL);
+	airspy_get_samplerates(device, &count, 0);
 	supported_samplerates = (uint32_t *) malloc(count * sizeof(uint32_t));
 	airspy_get_samplerates(device, supported_samplerates, count);
 	for(i=0;i<count;i++) {

--- a/air.c
+++ b/air.c
@@ -32,6 +32,10 @@ extern int nbch;
 extern pthread_barrier_t Bar1, Bar2;
 extern int gain;
 
+unsigned int SDRINRATE = 6000000;
+unsigned int SDRCLK = 1500;
+
+unsigned uint64_t airspy_serial;
 unsigned int Fc;
 
 static struct airspy_device* device = NULL;
@@ -42,21 +46,24 @@ static const unsigned int r820t_lf[]={525548,656935,795424,898403,1186034,150207
 static unsigned int chooseFc(unsigned int minF,unsigned int maxF)
 {
         unsigned int bw=maxF-minF+2*STEPRATE;
-        unsigned int off;
+        unsigned int off=0;
         int i,j;
 
-        for(i=7;i>=0;i--)
+        if(SDRINRATE == 5000000) {
+            /* This feature is specific to the R820T2 tuner in the Airspy R2 where the Mini has an R860. */
+            for(i=7;i>=0;i--)
                 if((r820t_hf[5]-r820t_lf[i])>=bw) break;
-        if(i<0) return 0;
+            if(i<0) return 0;
 
-        for(j=5;j>=0;j--)
+            for(j=5;j>=0;j--)
                 if((r820t_hf[j]-r820t_lf[i])<=bw) break;
-        j++;
+            j++;
 
-        off=(r820t_hf[j]+r820t_lf[i])/2-SDRINRATE/4;
+            off=(r820t_hf[j]+r820t_lf[i])/2-SDRINRATE/4;
 
-        airspy_r820t_write(device, 10, 0xB0 | (15-j));
-        airspy_r820t_write(device, 11, 0xE0 | (15-i));
+            airspy_r820t_write(device, 10, 0xB0 | (15-j));
+            airspy_r820t_write(device, 11, 0xE0 | (15-i));
+        }
 
         return(((maxF+minF)/2+off+STEPRATE/2)/STEPRATE*STEPRATE);
 }
@@ -98,8 +105,16 @@ int initAirspy(char **argv, int optind, thread_param_t * param)
 		return 1;
 	}
 
-	result = airspy_open(&device);
-	if( result != AIRSPY_SUCCESS ) {
+        if( airspy_serial ) {
+	    if (verbose) {
+		fprintf(stderr, "Attempting to open airspy device 0x%016lx\n", airspy_serial);
+	    }
+	    result = airspy_open_sn(&device, airspy_serial);
+	} else {
+	    result = airspy_open(&device);
+	}
+        
+        if( result != AIRSPY_SUCCESS ) {
 		fprintf(stderr,"airspy_open() failed: %s (%d)\n", airspy_error_name(result), result);
 		return -1;
 	}
@@ -111,11 +126,19 @@ int initAirspy(char **argv, int optind, thread_param_t * param)
 		return -1;
 	}
 
-	airspy_get_samplerates(device, &count, 0);
+	airspy_get_samplerates(device, &count, NULL);
 	supported_samplerates = (uint32_t *) malloc(count * sizeof(uint32_t));
 	airspy_get_samplerates(device, supported_samplerates, count);
-	for(i=0;i<count;i++)
-		if(supported_samplerates[i]==SDRINRATE) break;
+	for(i=0;i<count;i++) {
+            if( (supported_samplerates[i] == 5000000) /* AirSpy R2 */
+                    || (supported_samplerates[i] == 6000000)) /* AirSpy Mini */
+            {
+                SDRINRATE = supported_samplerates[i];
+                SDRCLK = SDRINRATE/4000;
+                break;
+            }
+        }
+
 	if(i>=count) {
 		fprintf(stderr,"did not find needed sampling rate\n");
 		return -1;

--- a/main.c
+++ b/main.c
@@ -52,6 +52,7 @@ int ppm = 0;
 #endif
 #ifdef WITH_AIR
 int gain = 21;
+uint64_t airspy_serial = 0;
 #endif
 
 int nbch;
@@ -65,6 +66,9 @@ static void usage(void)
 	fprintf(stderr, "Usage: vdlm2dec  [-J] [-q] [-j addr:port ] [-l logfile] [-g gain]");
 #ifdef WITH_RTL
 	fprintf(stderr, " [-p ppm] -r rtldevicenumber");
+#endif
+#ifdef WITH_AIR
+	fprintf(stderr, " [-k airspy_serial_number]");
 #endif
 	fprintf(stderr, " Frequencies(Mhz)\n\n");
 
@@ -91,6 +95,8 @@ static void usage(void)
 #ifdef WITH_AIR
 	fprintf(stderr,
 		" -g gain :\t\tset linearity gain (0 to 21).By default use maximum gain\n");
+	fprintf(stderr,
+		" -k serial :\t\tairspy serial number to bind to in hex, ie 0xA74068C82F2E3793\n");
 #endif
 	exit(1);
 }
@@ -115,7 +121,7 @@ int main(int argc, char **argv)
 	nbch = 0;
 	logfd = stdout;
 
-	while ((c = getopt(argc, argv, "vqrp:g:l:JRj:i:GEUt:b:a:")) != EOF) {
+	while ((c = getopt(argc, argv, "vqrp:g:k:l:JRj:i:GEUt:b:a:")) != EOF) {
 		switch (c) {
 		case 'v':
 			verbose = 2;
@@ -144,6 +150,9 @@ int main(int argc, char **argv)
 #ifdef WITH_AIR
 		case 'g':
 			gain = atoi(optarg);
+			break;
+		case 'k':
+			airspy_serial = strtoull(optarg, NULL, 16);
 			break;
 #endif
 		case 'j':

--- a/rtl.c
+++ b/rtl.c
@@ -31,6 +31,9 @@ extern int nbch;
 extern pthread_barrier_t Bar1, Bar2;
 extern int gain;
 
+unsigned int SDRINRATE = 2000000;
+unsigned int SDRCLK = 500;
+
 unsigned int Fc;
 
 static rtlsdr_dev_t *dev = NULL;

--- a/vdlm2.h
+++ b/vdlm2.h
@@ -24,17 +24,8 @@
 
 #define MAX_ID_LEN 48
 
-#ifdef WITH_RTL
-#define SDRINRATE 2000000
-#define SDRCLK  500
-//#define SDRINRATE 2500000
-//#define SDRCLK  625
-#endif
-
-#ifdef WITH_AIR
-#define SDRINRATE 5000000
-#define SDRCLK  1250
-#endif
+extern int SDRINRATE;
+extern int SDRCLK;
 
 #define STEPRATE 25000
 

--- a/vdlm2.h
+++ b/vdlm2.h
@@ -24,8 +24,8 @@
 
 #define MAX_ID_LEN 48
 
-extern int SDRINRATE;
-extern int SDRCLK;
+extern unsigned int SDRINRATE;
+extern unsigned int SDRCLK;
 
 #define STEPRATE 25000
 


### PR DESCRIPTION
Adds the option to choose a specific airspy device while retaining existing parameter compatibility.