### PR TITLE
Enable airspy USB bitpacked samples to reduce USB bandwidth

### DIFF
--- a/air.c
+++ b/air.c
@@ -153,8 +153,8 @@ int initAirspy(char **argv, int optind, thread_param_t * param)
 		return -1;
 	}
 
-       /* had problem with packing , disable it*/
-        airspy_set_packing(device, 0);
+       /* enable packed samples */
+        airspy_set_packing(device, 1);
 
         result = airspy_set_linearity_gain(device, gain);
         if( result != AIRSPY_SUCCESS ) {


### PR DESCRIPTION
I've been running bitpacked vdlm2dec with airspy mini's for over a week without issue and message rates consistent with previous weeks.